### PR TITLE
Save models as .safetensors

### DIFF
--- a/BlockMerge_Gradient_Tensors.py
+++ b/BlockMerge_Gradient_Tensors.py
@@ -167,7 +167,7 @@ def main(args):
 
         if args.output_model_path:
             print(f"{datetime.now().strftime('%H:%M:%S')} - Saving new model...")
-            model1.save_pretrained(args.output_model_path, max_shard_size=args.max_shard_size)
+            model1.save_pretrained(args.output_model_path, max_shard_size=args.max_shard_size, safe_serialization=True)
 
             print(f"{datetime.now().strftime('%H:%M:%S')} - Saved to: {args.output_model_path}")
             print(f"{datetime.now().strftime('%H:%M:%S')} - Copying files to: {args.output_model_path}")

--- a/OUTDATED_BlockMerge_Gradient.py
+++ b/OUTDATED_BlockMerge_Gradient.py
@@ -131,7 +131,7 @@ def main(args):
 
         if args.output_model_path:
             print(f"{datetime.now().strftime('%H:%M:%S')} - Saving new model...")
-            model1.save_pretrained(args.output_model_path, max_shard_size=args.max_shard_size)
+            model1.save_pretrained(args.output_model_path, max_shard_size=args.max_shard_size, safe_serialization=True)
 
             print(f"{datetime.now().strftime('%H:%M:%S')} - Saved to: {args.output_model_path}")
             print(f"{datetime.now().strftime('%H:%M:%S')} - Copying files to: {args.output_model_path}")

--- a/YAML/BlockMerge_Gradient_Tensors_YAML.py
+++ b/YAML/BlockMerge_Gradient_Tensors_YAML.py
@@ -180,7 +180,7 @@ def main_from_config(config):
         if config['output_model_path']:
             print(f"{datetime.now().strftime('%H:%M:%S')} - Saving new model...")
             model1.half()
-            model1.save_pretrained(config['output_model_path'], max_shard_size=config.get('max_shard_size', "2000MiB"))
+            model1.save_pretrained(config['output_model_path'], max_shard_size=config.get('max_shard_size', "2000MiB"), safe_serialization=True)
 
             print(f"{datetime.now().strftime('%H:%M:%S')} - Saved to: {config['output_model_path']}")
             print(f"{datetime.now().strftime('%H:%M:%S')} - Copying files to: {config['output_model_path']}")


### PR DESCRIPTION
There are two advantages to this:

1) The [convert.py](https://github.com/turboderp/exllamav2/blob/master/convert.py) script in the exllamav2 repository expects models to be in .safetensors format. It is possible to convert .bin to .safetensors, but that takes additional time and storage.
2) Models in .safetensors format load faster with `.from_pretrained()`.